### PR TITLE
Fix bug in helperFuncs introduced in 529436b

### DIFF
--- a/src/scripts/test/utils/helperFuncsTest.js
+++ b/src/scripts/test/utils/helperFuncsTest.js
@@ -1,0 +1,14 @@
+import helperFuncs from '../../utils/helperFuncs.js'
+import should from "should";
+
+describe('helperFuncs.toArray', () => {
+  it('should convert all object values to an array', () => {
+    should(helperFuncs.toArray({
+      key1: "value 1",
+      key2: "value 2"
+    })).eql([
+      "value 1",
+      "value 2"
+    ]).which.is.an.Array();
+  })
+});

--- a/src/scripts/utils/helperFuncs.js
+++ b/src/scripts/utils/helperFuncs.js
@@ -92,7 +92,11 @@ function filterBy (name, value) {
 
 // turn an object into an array
 function toArray (obj) {
-  return Array.from(obj);
+  var arr = [];
+  for ( var key in obj ) {
+      arr.push(obj[key]);
+  }
+  return arr;
 }
 
 // strip tags from description text and return


### PR DESCRIPTION
Fixed helperFuncs.toArray. 529436b attempts to implement it with
`Array.from()` but failed.
